### PR TITLE
removing all blacklisting and flagging. it's failing in prod and we don't even use it

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -21,53 +21,17 @@ var flagSchema = new mongoose.Schema({
 function profanityPlugin (schema, options) {
     options = options || {};
 
-    var flagsToBlacklist = typeof options.maxFlags !== 'undefined' ? options.maxFlags : false;
-
-    if (flagsToBlacklist) {
-        schema.add({
-            flags: {
-                type: [ flagSchema ]
-            },
-            blackListed: {
-                type: Boolean,
-                default: false
-            }
-        });
-    }
-
     schema.pre('save', function (next) {
 
-        var entry = this,
-            result = profanity.purify(entry._doc, options),
-            matched = result[1];
-
-        if(flagsToBlacklist){
-          matched.forEach(function () {
-              entry.flags.push({ author: null, reason: 'Inappropriate language' });
-          });
-
-          if (flagsToBlacklist && entry.flags.length >= flagsToBlacklist) {
-              entry.blackListed = true;
-          }
-        }
+        var entry = this;
+        var result = profanity.purify(entry._doc, options);
 
         next();
     });
 
     schema.pre('update', function (next) {
-        var entry = this,
-            result = profanity.purify(entry._doc, options),
-            matched = result[1];
-
-        if(flagsToBlacklist){
-          matched.forEach(function () {
-              entry.flags.push({ author: null, reason: 'Inappropriate language' });
-          });
-
-          if (flagsToBlacklist && entry.flags.length >= flagsToBlacklist) {
-              entry.blackListed = true;
-          }
-        }
+      var entry = this;
+      var result = profanity.purify(entry._doc, options);
 
         next();
     });

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -144,50 +144,13 @@ describe('Profanity plugin', function() {
     });
   });
 
-  it('adds a flag for each bad word used, only in configured schema fields', function(done) {
-    true.should.be.ok;
-
-    var test = new Test({title: 'Test crap boob', description: 'bollok', immune: 'butt damn'});
-
-    test.save(function(err, entry) {
-      if (err) {
-        throw err;
-      }
-
-      entry.flags.should.have.length(3);
-      should(entry.flags[0].author).equal(null);
-      entry.flags[0].reason.should.equal('Inappropriate language');
-      entry.title.should.equal('Test c**p b**b');
-      entry.description.should.equal('b****k');
-      entry.immune.should.equal('butt damn');
-      should(entry.blackListed).equal(false);
-
-      done();
-    });
-  });
-
-  it('blacklists object correctly when finds more swearwords', function(done) {
-    new Test({title: 'testing poo foo crap bar damn somthing butt bar fanny'}).save(function(err, entry) {
-      if (err) {
-        throw err;
-      }
-
-      entry.flags.should.have.length(5);
-      entry.blackListed.should.be.ok;
-
-      done();
-    });
-  });
-
   it('works correctly with partial replace option', function(done) {
     new Test2({text: 'testing poop something partial replace'}).save(function(err, entry) {
       if (err) {
         throw err;
       }
 
-      entry.flags.should.have.length(1);
       entry.text.should.equal('testing p%%p something partial replace');
-      entry.blackListed.should.not.be.ok;
 
       done();
     });
@@ -198,8 +161,6 @@ describe('Profanity plugin', function() {
       if (err) {
         throw err;
       }
-
-      entry.blackListed.should.be.ok;
 
       util.testPurified(entry.text, '[ placeholder ] unchanged [ placeholder ] unchanged [ placeholder ] unchanged', 'oof|rab|tset');
 


### PR DESCRIPTION
the line `matched = result[1]` is failing in prod when `result` is undefined. String replacement happens regardless of all of that; this is only used to add flags and blacklists, which we do not use.

Replacing all of that and fixing tests for it.

Huge departure from the repo we forked, API-wise.